### PR TITLE
move HMODULE m declaration to top

### DIFF
--- a/src/win_delay_load_hook.c
+++ b/src/win_delay_load_hook.c
@@ -16,6 +16,7 @@
 #include <string.h>
 
 static FARPROC WINAPI load_exe_hook(unsigned int event, DelayLoadInfo* info) {
+  HMODULE m;
   if (event != dliNotePreLoadLibrary)
     return NULL;
 
@@ -23,7 +24,7 @@ static FARPROC WINAPI load_exe_hook(unsigned int event, DelayLoadInfo* info) {
       _stricmp(info->szDll, "node.exe") != 0)
     return NULL;
 
-  HMODULE m = GetModuleHandle(NULL);
+  m = GetModuleHandle(NULL);
   return (FARPROC) m;
 }
 


### PR DESCRIPTION
Needed for the function to be C89 compatible, so it compiles with Visual Studio 2013.
